### PR TITLE
Fix campaign start crash

### DIFF
--- a/CSharpSourceCode/HarmonyPatches/FactionBannerPatches.cs
+++ b/CSharpSourceCode/HarmonyPatches/FactionBannerPatches.cs
@@ -27,7 +27,7 @@ namespace TOW_Core.HarmonyPatches
 			string code = node?.Attributes?.GetNamedItem("banner_key").Value;
 			if (code != null)
 			{
-				_cache.Add(__instance.StringId, new Banner(code));
+				_cache[__instance.StringId] = new Banner(code);
 			}
 		}
 
@@ -38,7 +38,7 @@ namespace TOW_Core.HarmonyPatches
 			string code = node?.Attributes?.GetNamedItem("banner_key").Value;
 			if (code != null)
 			{
-				_cache.Add(__instance.StringId, new Banner(code));
+				_cache[__instance.StringId] = new Banner(code);
 			}
 		}
 


### PR DESCRIPTION
There was a crash occurring if you started a campaign, backed out in
character selection, and attempted to start a new campaign. This fix
overwrites the Dictionary in FactionBannerPatches instead of using
.Add(), which throws an exception in the case the key already exists.