### PR TITLE
Hotfix null dismemberment victim

### DIFF
--- a/CSharpSourceCode/Battle/Dismemberment/DismembermentMissionLogic.cs
+++ b/CSharpSourceCode/Battle/Dismemberment/DismembermentMissionLogic.cs
@@ -34,6 +34,9 @@ namespace TOW_Core.Battle.Dismemberment
         {
             base.OnRegisterBlow(attacker, victim, realHitEntity, blow, ref collisionData, attackerWeapon);
 
+            if (victim == null)
+                return;
+
             bool canBeDismembered = victim.IsHuman &&
                                     victim != Agent.Main &&
                                     victim.Health <= 0 &&

--- a/CSharpSourceCode/Battle/Dismemberment/DismembermentMissionLogic.cs
+++ b/CSharpSourceCode/Battle/Dismemberment/DismembermentMissionLogic.cs
@@ -34,10 +34,9 @@ namespace TOW_Core.Battle.Dismemberment
         {
             base.OnRegisterBlow(attacker, victim, realHitEntity, blow, ref collisionData, attackerWeapon);
 
-            if (victim == null)
-                return;
-
-            bool canBeDismembered = victim.IsHuman &&
+            bool canBeDismembered = victim != null &&
+                                    attacker != null &&
+                                    victim.IsHuman &&
                                     victim != Agent.Main &&
                                     victim.Health <= 0 &&
                                     ((attacker != Agent.Main && canTroopDismember) ||


### PR DESCRIPTION
Sometimes a blow was registered with no victim. canBeDismembered is now set to false in that case, and also if the attacker is null (avoid NPE there too)