### PR TITLE
Fixing dot for status effect

### DIFF
--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffect.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffect.cs
@@ -38,6 +38,8 @@ namespace TOW_Core.Battle.StatusEffects
         [XmlIgnore]
         public Agent Affector { get; set; }
 
+        public int AffectorID;
+
         public enum EffectType
         {
             Armor,

--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffect.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffect.cs
@@ -38,8 +38,6 @@ namespace TOW_Core.Battle.StatusEffects
         [XmlIgnore]
         public Agent Affector { get; set; }
 
-        public int AffectorID;
-
         public enum EffectType
         {
             Armor,

--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffect.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffect.cs
@@ -34,7 +34,7 @@ namespace TOW_Core.Battle.StatusEffects
         public EffectType Type { get; set; }
 
         [XmlIgnore]
-        public int CurrentDuration { get; set; }
+        public float CurrentDuration { get; set; }
         [XmlIgnore]
         public Agent Affector { get; set; }
 

--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffectComponent.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffectComponent.cs
@@ -27,10 +27,8 @@ namespace TOW_Core.Battle.StatusEffects
             _effectAggregate = new EffectAggregate(); 
         }
 
-        public void RunStatusEffect(string id)
+        public void RunStatusEffect(string id, Agent affector=null)
         {
-            
-            
             if(Agent == null)
                 return;
             
@@ -43,8 +41,10 @@ namespace TOW_Core.Battle.StatusEffects
             {
                 //
                 effect = StatusEffectManager.GetStatusEffect(id);
-                TOWCommon.Say(effect.Duration+ "is added");
+              //  TOWCommon.Say(effect.Duration+ "is added");
                 effect.CurrentDuration= effect.Duration;
+                if(affector!=null)
+                    effect.Affector = affector;
                 AddEffect(effect);
             }
         }
@@ -55,6 +55,8 @@ namespace TOW_Core.Battle.StatusEffects
             {
                 return;
             }
+
+            Agent affector = null;
             
             foreach (StatusEffect effect in _currentEffects.Keys.ToList())
             {
@@ -66,6 +68,8 @@ namespace TOW_Core.Battle.StatusEffects
                     //TOWCommon.Say("effect has gone");
                     return;
                 }
+                if(effect.Affector!=null)
+                    affector = effect.Affector;
 
                 if (effect.CurrentDuration > 0)
                 {
@@ -80,13 +84,15 @@ namespace TOW_Core.Battle.StatusEffects
                 if(_effectAggregate.HealthOverTime < 0)
                 {
                    // TOWCommon.Say("apply damage :" +(int)_effectAggregate.HealthOverTime );
-                    Agent.ApplyDamage(-1 * ((int)_effectAggregate.HealthOverTime), null, false, false);
+                    Agent.ApplyDamage(-1 * ((int)_effectAggregate.HealthOverTime), affector, false, false);
                 }
                 else if(_effectAggregate.HealthOverTime > 0)
                 {
                     Agent.Heal((int)_effectAggregate.HealthOverTime);
                 }
+                
             }
+            
 
             
         }

--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffectMissionLogic.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffectMissionLogic.cs
@@ -46,16 +46,18 @@ namespace TOW_Core.Battle.StatusEffects
             {
                 if (agent.GetComponent<StatusEffectComponent>() != null)
                 {
+                    if (agent.GetComponent<StatusEffectComponent>().IsDisabled())
+                    {
+                        activeAgents.Remove(agent);
+                        continue;
+                    }
                     if (agent.IsActive() && agent.Health > 1f)
                     {
                         var comp = agent.GetComponent<StatusEffectComponent>();
                         comp.OnTick(dt);
                     }
 
-                    if (agent.GetComponent<StatusEffectComponent>().IsDisabled())
-                    {
-                        activeAgents.Remove(agent);
-                    }
+                    
                 }
             }
         }

--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffectMissionLogic.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffectMissionLogic.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using TaleWorlds.CampaignSystem;
 using TaleWorlds.CampaignSystem.GameMenus;
@@ -15,18 +16,33 @@ namespace TOW_Core.Battle.StatusEffects
 {
     public class StatusEffectMissionLogic : MissionLogic
     {
+        public List<Agent> activeAgents;
+        private bool init;
+
+      
         public override void OnAgentCreated(Agent agent)
         {
+            if (activeAgents == null&&!init)
+            {
+                activeAgents = new List<Agent>();
+                init = true;
+            }
+            
             if (agent.IsHuman)
             {
                 StatusEffectComponent effectComponent = new StatusEffectComponent(agent);
                 agent.AddComponent(effectComponent);
+                activeAgents.Add(agent);
             }
         }
         
         public override void OnMissionTick(float dt)
         {
-            foreach(var agent in Mission.Current.Agents)
+            
+            if (!init)
+                return;
+            
+            foreach(var agent in activeAgents.ToList())
             {
                 if (agent.GetComponent<StatusEffectComponent>() != null)
                 {
@@ -35,8 +51,24 @@ namespace TOW_Core.Battle.StatusEffects
                         var comp = agent.GetComponent<StatusEffectComponent>();
                         comp.OnTick(dt);
                     }
+
+                    if (agent.GetComponent<StatusEffectComponent>().IsDisabled())
+                    {
+                        activeAgents.Remove(agent);
+                    }
                 }
             }
+        }
+
+        public void RemoveAgent(Agent agent, Blow test)
+        {
+            if (activeAgents.Contains(agent))
+            {
+                agent.GetComponent<StatusEffectComponent>().RenderDisabled(true);
+                //agent.Die(test);
+            }
+            
+            
         }
     }
 }

--- a/CSharpSourceCode/Battle/StatusEffects/StatusEffectMissionLogic.cs
+++ b/CSharpSourceCode/Battle/StatusEffects/StatusEffectMissionLogic.cs
@@ -16,15 +16,15 @@ namespace TOW_Core.Battle.StatusEffects
 {
     public class StatusEffectMissionLogic : MissionLogic
     {
-        public List<Agent> activeAgents;
+        private Dictionary<int, Agent> _activeAgents;
         private bool init;
 
       
         public override void OnAgentCreated(Agent agent)
         {
-            if (activeAgents == null&&!init)
+            if (_activeAgents == null&&!init)
             {
-                activeAgents = new List<Agent>();
+                _activeAgents = new Dictionary<int, Agent>(); 
                 init = true;
             }
             
@@ -32,7 +32,7 @@ namespace TOW_Core.Battle.StatusEffects
             {
                 StatusEffectComponent effectComponent = new StatusEffectComponent(agent);
                 agent.AddComponent(effectComponent);
-                activeAgents.Add(agent);
+                _activeAgents?.Add(agent.Index, agent);
             }
         }
         
@@ -41,19 +41,19 @@ namespace TOW_Core.Battle.StatusEffects
             
             if (!init)
                 return;
-            
-            foreach(var agent in activeAgents.ToList())
+
+            foreach (var agent in _activeAgents.ToDictionary(x =>x.Key, x=> x.Value))
             {
-                if (agent.GetComponent<StatusEffectComponent>() != null)
+                if (agent.Value.GetComponent<StatusEffectComponent>() != null)
                 {
-                    if (agent.GetComponent<StatusEffectComponent>().IsDisabled())
+                    if (agent.Value.GetComponent<StatusEffectComponent>().IsDisabled())
                     {
-                        activeAgents.Remove(agent);
+                        _activeAgents.Remove(agent.Key);
                         continue;
                     }
-                    if (agent.IsActive() && agent.Health > 1f)
+                    if (agent.Value.IsActive() && agent.Value.Health > 1f)
                     {
-                        var comp = agent.GetComponent<StatusEffectComponent>();
+                        var comp = agent.Value.GetComponent<StatusEffectComponent>();
                         comp.OnTick(dt);
                     }
 
@@ -62,14 +62,12 @@ namespace TOW_Core.Battle.StatusEffects
             }
         }
 
-        public void RemoveAgent(Agent agent, Blow test)
+        public void RemoveAgent(Agent agent)
         {
-            if (activeAgents.Contains(agent))
+            if (_activeAgents.Values.Contains(agent))
             {
                 agent.GetComponent<StatusEffectComponent>().RenderDisabled(true);
-                //agent.Die(test);
             }
-            
             
         }
     }

--- a/CSharpSourceCode/Battle/TOWBattleUtilities.cs
+++ b/CSharpSourceCode/Battle/TOWBattleUtilities.cs
@@ -47,7 +47,15 @@ namespace TOW_Core.Battle
         {
             foreach (var agent in agents)
             {
-                agent.ApplyStatusEffect(effectId);
+                if (damager != null)
+                {
+                    agent.ApplyStatusEffect(effectId,damager);
+                }
+                else
+                {
+                    agent.ApplyStatusEffect(effectId);
+                }
+                
             }
         }
     }

--- a/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
+++ b/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -177,7 +177,7 @@ namespace TOW_Core.Utilities.Extensions
                     if (!doBlow && agent.Health > damageAmount + 1)
                     {
                         agent.Health -= damageAmount;
-                        TOWCommon.Say(agent.Name+agent.Index+" health:"+ (agent.Health+damageAmount)+ "-"+ damageAmount +"= "+ agent.Health);
+                       // TOWCommon.Say(agent.Name+agent.Index+" health:"+ (agent.Health+damageAmount)+ "-"+ damageAmount +"= "+ agent.Health);
                         return;
                     }
                     
@@ -193,6 +193,12 @@ namespace TOW_Core.Utilities.Extensions
                         blow.DamageType = DamageTypes.Invalid;
                         blow.VictimBodyPart = BoneBodyPartType.Chest;
                         blow.StrikeType = StrikeType.Invalid;
+
+                        if (damager == null)
+                        {
+                            TOWCommon.Say("damager not found");
+                        }
+                        
                         if (hasShockWave)
                         {
                             if (agent.HasMount)
@@ -202,9 +208,9 @@ namespace TOW_Core.Utilities.Extensions
                         }
                         if (damager != null)
                         {
-                            var checkAgent = Mission.Current.FindAgentWithIndex(damager.Index);
-                            if (checkAgent != null && checkAgent.Equals(damager)) blow.OwnerId = damager.Index;
-                            //blow.OwnerId = damager.Index;
+                            //var checkAgent = Mission.Current.FindAgentWithIndex(damager.Index);
+                            //if (checkAgent != null && checkAgent.Equals(damager)) blow.OwnerId = damager.Index;
+                            blow.OwnerId = damager.Index;
                         }
                         else
                         {
@@ -216,15 +222,20 @@ namespace TOW_Core.Utilities.Extensions
                         
                         agent.RegisterBlow(blow);
 
-                        if (agent.Health < damageAmount)
+                        if (agent.Health <= damageAmount)
                         {
                             
                             if (Mission.Current.GetMissionBehaviour<StatusEffectMissionLogic>() != null)
                             {
-                                Mission.Current.GetMissionBehaviour<StatusEffectMissionLogic>().RemoveAgent(agent,blow); 
+                                Mission.Current.GetMissionBehaviour<StatusEffectMissionLogic>().RemoveAgent(agent); 
                             }
-                            if(!doBlow) TOWCommon.Say(agent.Name+agent.Index+" died of dot");
-                            //agent.RegisterBlow(blow);
+
+                            if (damager != null&&!doBlow)
+                            {
+                                blow.OwnerId = damager.Index;
+                            }
+
+                            if (!doBlow) TOWCommon.Say(agent.Name + agent.Index + " died of dot");
                             agent.Die(blow);
                         }
                         
@@ -254,7 +265,7 @@ namespace TOW_Core.Utilities.Extensions
 
         public static void ApplyStatusEffect(this Agent agent, string effectId, Agent damager = null)
         {
-            agent.GetComponent<StatusEffectComponent>().RunStatusEffect(effectId);
+            agent.GetComponent<StatusEffectComponent>().RunStatusEffect(effectId,damager);
         }
 
         #region voice
@@ -289,20 +300,6 @@ namespace TOW_Core.Utilities.Extensions
         {
             agent.AgentVisuals.SetVisible(false);
         }
-
-        public static void KillImmediately(this Agent agent, Agent damager=null)
-        {
-            var blow = new Blow(-1);
-            blow.InflictedDamage = 0;
-            blow.DamageCalculated = true;
-            blow.InflictedDamage = 1;
-            blow.AttackType = AgentAttackType.Kick;
-            blow.BlowFlag = BlowFlags.NoSound;
-            blow.BaseMagnitude = 5;
-            blow.DamageType = DamageTypes.Invalid;
-            blow.VictimBodyPart = BoneBodyPartType.Chest;
-            blow.StrikeType = StrikeType.Invalid;
-            agent.Die(blow);
-        }
+        
     }
 }

--- a/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
+++ b/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
@@ -209,6 +209,26 @@ namespace TOW_Core.Utilities.Extensions
                         }
                         agent.RegisterBlow(blow);
                     }
+
+                    if (agent.Health < damageAmount)
+                    {
+                        var blow = new Blow(-1);
+                        blow.AttackType = AgentAttackType.Kick;
+                        blow.InflictedDamage = damageAmount;
+                        blow.BlowFlag = BlowFlags.NoSound;
+                        blow.BaseMagnitude = 5;
+                        blow.DamageType = DamageTypes.Invalid;
+                        blow.VictimBodyPart = BoneBodyPartType.Chest;
+                        if (Mission.Current.GetMissionBehaviour<StatusEffectMissionLogic>() != null)
+                        {
+                            Mission.Current.GetMissionBehaviour<StatusEffectMissionLogic>().RemoveAgent(agent,blow); 
+                        }
+                        
+                        agent.Die(blow);
+                        TOWCommon.Say(agent.Name+ "died");
+                    }
+                    
+                    
                 }
             }
             catch (Exception e)

--- a/ModuleData/tow_statuseffects.xml
+++ b/ModuleData/tow_statuseffects.xml
@@ -18,7 +18,7 @@
 		id="fireball_dot" 
 		particle_id="torch_fire_sparks"
 		particle_intensity="High"
-		health_over_time="-1"
-		duration="12"
+		health_over_time="-5"
+		duration="30"
 		type="Health"/>
 </StatusEffects>


### PR DESCRIPTION
This change allows again to kill agents  by using a dot effect. It also assigns the Affector as the killer. If there would be multiple affectors, only the dominant affector becomes the killer. if the Status effect is world inflicted (like crumbling) the death is counted as suicide. The damage of the fire effect is slightly enhanced, to account better for damaging via dot. This text sounds depressing. 