### PR TITLE
Fixes for damage system

### DIFF
--- a/CSharpSourceCode/Battle/Damage/DamageType.cs
+++ b/CSharpSourceCode/Battle/Damage/DamageType.cs
@@ -8,6 +8,7 @@ namespace TOW_Core.Battle.Damage
 {
     public enum DamageType
     {
+        Invalid,
         Physical,
         Magical,
         Fire,

--- a/CSharpSourceCode/Battle/Damage/DamageType.cs
+++ b/CSharpSourceCode/Battle/Damage/DamageType.cs
@@ -8,7 +8,6 @@ namespace TOW_Core.Battle.Damage
 {
     public enum DamageType
     {
-        Invalid,
         Physical,
         Magical,
         Fire,

--- a/CSharpSourceCode/HarmonyPatches/DamagePatch.cs
+++ b/CSharpSourceCode/HarmonyPatches/DamagePatch.cs
@@ -1,10 +1,12 @@
 using System.Globalization;
 using HarmonyLib;
+using TaleWorlds.CampaignSystem;
 using TaleWorlds.Core;
 using TaleWorlds.Library;
 using TaleWorlds.MountAndBlade;
 using TOW_Core.Battle.Damage;
 using TOW_Core.ObjectDataExtensions;
+using TOW_Core.Utilities;
 using TOW_Core.Utilities.Extensions;
 namespace TOW_Core.HarmonyPatches
 {
@@ -22,6 +24,11 @@ namespace TOW_Core.HarmonyPatches
             {
                 return true;
             }
+            
+            if (attacker == victim)
+            {
+                return true;
+            }
 
             bool isSpell = false;
             float[] damageCategories=new float[(int) DamageType.All+1];
@@ -32,7 +39,7 @@ namespace TOW_Core.HarmonyPatches
             var damagePercentages = attackerPropertyContainer.DamagePercentages;
             //defense properties
             var resistancePercentages = victimPropertyContainer.ResistancePercentages;
-
+            
             if (b.StrikeType == StrikeType.Invalid && b.AttackType == AgentAttackType.Kick && b.DamageCalculated)
             {
                 isSpell = true;
@@ -47,15 +54,15 @@ namespace TOW_Core.HarmonyPatches
                 damageCategories[damageType] *= 1 + damagePercentages[damageType];
                 b.InflictedDamage = (int)damageCategories[damageType];
                 if(attacker==Agent.Main || victim==Agent.Main)
-                    DisplaySpellDamageResult(spellInfo.SpellID,spellInfo.DamageType,b.InflictedDamage,damagePercentages[damageType]);
+                    TORDamageDisplay.DisplaySpellDamageResult(spellInfo.SpellID,spellInfo.DamageType,b.InflictedDamage,damagePercentages[damageType]);
                 return true;
             }
 
             var resultDamage = 0;
-            for (int i = 0; i < damageCategories.Length; i++)
+            for (int i = 0; i < damageCategories.Length-1; i++)
             {
                 damageCategories[i] = b.InflictedDamage * damageProportions[i];
-
+                damageCategories[i] += damageCategories[(int)DamageType.All]/(int) DamageType.All;
                 if (damageCategories[i] > 0)
                 {
                     damagePercentages[i] -= resistancePercentages[i];
@@ -69,89 +76,11 @@ namespace TOW_Core.HarmonyPatches
             if (b.InflictedDamage > 0)
             {
                 if(attacker==Agent.Main || victim==Agent.Main)
-                    DisplayDamageResult(resultDamage, damageCategories);
+                    TORDamageDisplay.DisplayDamageResult(resultDamage, damageCategories);
             }
             return true;
         }
 
-        private static void DisplaySpellDamageResult(string SpellName, DamageType additionalDamageType, 
-            int resultDamage, float damageAmplifier)
-        {
-            var displayColor = Color.White;
-            string displayDamageType = "";
-
-            switch (additionalDamageType)
-            {
-                case DamageType.Fire:
-                    displayColor = Colors.Red;
-                    displayDamageType = "fire";
-                    break;
-                case DamageType.Holy:
-                    displayColor = Colors.Yellow;
-                    displayDamageType = "holy";
-                    break;
-                case DamageType.Lightning:
-                    displayColor = Colors.Blue;
-                    displayDamageType = "lightning";
-                    break;
-                case DamageType.Magical:
-                    displayColor = Colors.Cyan;
-                    displayDamageType = "magical";
-                    break;
-                case DamageType.Physical:
-                    displayColor = Color.White;
-                    displayDamageType = "Physical";
-                    break;
-            }
-            InformationManager.DisplayMessage(new InformationMessage(resultDamage + "cast damage consisting of  "+" ("+displayDamageType +") was applied "+ "which was modified by " + (1+damageAmplifier).ToString("##%", CultureInfo.InvariantCulture) , displayColor));
-        }
         
-
-        private static void DisplayDamageResult(int resultDamage, float[] categories)
-        {
-            var displaycolor = Color.White;
-            var dominantAdditionalEffect = DamageType.Physical;
-            float dominantCategory=0;
-            string additionalDamageTypeText= "";
-            
-            for (int i = 2; i < categories.Length; i++) //starting from first real additional damage type
-            {
-                if (dominantCategory < categories[i])
-                {
-                    dominantCategory = categories[i];
-                    dominantAdditionalEffect = (DamageType) i;
-                }
-
-                if (categories[i] > 0)
-                {
-                    DamageType t = (DamageType)i;
-                    string s = ", " +(int) categories[i] + " was dealt in " + t;
-                    if (additionalDamageTypeText == "")
-                        additionalDamageTypeText = s;
-                    else
-                        additionalDamageTypeText.Add(s,false);
-                }
-            }
-
-            switch (dominantAdditionalEffect)
-            {
-                case DamageType.Fire:
-                    displaycolor = Colors.Red;
-                    break;
-                case DamageType.Holy:
-                    displaycolor = Colors.Yellow;
-                    break;
-                case DamageType.Lightning:
-                    displaycolor = Colors.Blue;
-                    break;
-                case DamageType.Magical:
-                    displaycolor = Colors.Cyan;
-                    break;
-            }
-
-            var resultText = (int) resultDamage+ " damage was dealt of which was "+ (int) categories[1]+ " "+ nameof(DamageType.Physical)+additionalDamageTypeText;
-            InformationManager.DisplayMessage(new InformationMessage(resultText, displaycolor));
-            
-        }
     }
 }

--- a/CSharpSourceCode/Items/ExtendedItemObjectProperties.cs
+++ b/CSharpSourceCode/Items/ExtendedItemObjectProperties.cs
@@ -23,8 +23,16 @@ namespace TOW_Core.Items
 
         public ExtendedItemObjectProperties() { }
 
-        public ExtendedItemObjectProperties(string id) => ItemStringId = id;
-
+        public ExtendedItemObjectProperties(string id, DamageType defaultDamageType= DamageType.Physical)
+        {
+            ItemStringId = id;
+            DamageProportionTuple proportionTuple = new DamageProportionTuple
+            {
+                DamageType = defaultDamageType,
+                Percent = 1f
+            };
+            DamageProportions.Add(proportionTuple);
+        }
         public static ExtendedItemObjectProperties CreateDefault(string id)
         {
             return new ExtendedItemObjectProperties(id);

--- a/CSharpSourceCode/ObjectDataExtensions/CharacterExtendedInfo.cs
+++ b/CSharpSourceCode/ObjectDataExtensions/CharacterExtendedInfo.cs
@@ -31,7 +31,7 @@ namespace TOW_Core.ObjectDataExtensions
     public class ResistanceTuple
     {
         [XmlAttribute]
-        public DamageType ResistedDamageType = DamageType.Invalid;
+        public DamageType ResistedDamageType = DamageType.Physical;
         [XmlAttribute]
         public float ReductionPercent = 0;
     }
@@ -40,7 +40,7 @@ namespace TOW_Core.ObjectDataExtensions
     public class AmplifierTuple
     {
         [XmlAttribute]
-        public DamageType AmplifiedDamageType = DamageType.Invalid;
+        public DamageType AmplifiedDamageType = DamageType.Physical;
         [XmlAttribute]
         public float DamageAmplifier = 0;
     }

--- a/CSharpSourceCode/ObjectDataExtensions/CharacterExtendedInfo.cs
+++ b/CSharpSourceCode/ObjectDataExtensions/CharacterExtendedInfo.cs
@@ -31,7 +31,7 @@ namespace TOW_Core.ObjectDataExtensions
     public class ResistanceTuple
     {
         [XmlAttribute]
-        public DamageType ResistedDamageType = DamageType.Physical;
+        public DamageType ResistedDamageType = DamageType.Invalid;
         [XmlAttribute]
         public float ReductionPercent = 0;
     }
@@ -40,7 +40,7 @@ namespace TOW_Core.ObjectDataExtensions
     public class AmplifierTuple
     {
         [XmlAttribute]
-        public DamageType AmplifiedDamageType = DamageType.Physical;
+        public DamageType AmplifiedDamageType = DamageType.Invalid;
         [XmlAttribute]
         public float DamageAmplifier = 0;
     }
@@ -49,7 +49,7 @@ namespace TOW_Core.ObjectDataExtensions
     public class DamageProportionTuple
     {
         [XmlAttribute]
-        public DamageType DamageType = DamageType.Physical;
+        public DamageType DamageType = DamageType.Invalid;
         [XmlAttribute]
         public float Percent = 1;
     }

--- a/CSharpSourceCode/TOW_Core.csproj
+++ b/CSharpSourceCode/TOW_Core.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <!-- Bannerlord path Property-->
   <PropertyGroup>
-    <GameDir>G:\Program Files (x86)\SteamLibrary\steamapps\common\Mount &amp; Blade II Bannerlord</GameDir>
+    <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord</GameDir>
   </PropertyGroup>
   <!-- Debug Configuration Properties -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CSharpSourceCode/TOW_Core.csproj
+++ b/CSharpSourceCode/TOW_Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Main Project Properties -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <!-- Bannerlord path Property-->
   <PropertyGroup>
-    <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord</GameDir>
+    <GameDir>G:\Program Files (x86)\SteamLibrary\steamapps\common\Mount &amp; Blade II Bannerlord</GameDir>
   </PropertyGroup>
   <!-- Debug Configuration Properties -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -475,6 +475,7 @@
     <Compile Include="Utilities\Extensions\MobilePartyExtensions.cs" />
     <Compile Include="Utilities\Extensions\SettlementExtensions.cs" />
     <Compile Include="Utilities\ShaderGameManager.cs" />
+    <Compile Include="Utilities\TORDamageDisplay.cs" />
     <Compile Include="Utilities\TORWorldMapScript.cs" />
     <Compile Include="Utilities\TOWCommon.cs" />
     <Compile Include="Utilities\TOWDebug.cs" />

--- a/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
+++ b/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
@@ -192,11 +192,6 @@ namespace TOW_Core.Utilities.Extensions
                             {
                                 damageProportions[(int)tuple.DamageType] = tuple.Percent;
                             }
-
-                            if (damageProportions.Sum() == 0)
-                            {
-                                damageProportions[(int)DamageType.Physical] = 1;
-                            }
                         }
                         
                     }

--- a/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
+++ b/CSharpSourceCode/Utilities/Extensions/AgentExtensions.cs
@@ -355,7 +355,7 @@ namespace TOW_Core.Utilities.Extensions
             try
             {
                 // Registering a blow causes the agent to react/stagger. Manipulate health directly if the damage won't kill the agent.
-                if (agent.State == AgentState.Active)
+                if (agent.State == AgentState.Active|| agent.State == AgentState.Routed)
                 {
                     if (!doBlow && agent.Health > damageAmount )
                     {

--- a/CSharpSourceCode/Utilities/TORDamageDisplay.cs
+++ b/CSharpSourceCode/Utilities/TORDamageDisplay.cs
@@ -1,0 +1,89 @@
+﻿using System.Globalization;
+using TaleWorlds.Core;
+using TaleWorlds.Library;
+using TOW_Core.Battle.Damage;
+
+namespace TOW_Core.Utilities
+{
+    public static  class TORDamageDisplay
+    {
+        public static void DisplaySpellDamageResult(string SpellName, DamageType additionalDamageType, 
+            int resultDamage, float damageAmplifier)
+        {
+            var displayColor = Color.White;
+            string displayDamageType = "";
+
+            switch (additionalDamageType)
+            {
+                case DamageType.Fire:
+                    displayColor = Colors.Red;
+                    displayDamageType = "fire";
+                    break;
+                case DamageType.Holy:
+                    displayColor = Colors.Yellow;
+                    displayDamageType = "holy";
+                    break;
+                case DamageType.Lightning:
+                    displayColor = Colors.Blue;
+                    displayDamageType = "lightning";
+                    break;
+                case DamageType.Magical:
+                    displayColor = Colors.Cyan;
+                    displayDamageType = "magical";
+                    break;
+                case DamageType.Physical:
+                    displayColor = Color.White;
+                    displayDamageType = "Physical";
+                    break;
+            }
+            InformationManager.DisplayMessage(new InformationMessage(resultDamage + "cast damage consisting of  "+" ("+displayDamageType +") was applied "+ "which was modified by " + (1+damageAmplifier).ToString("##%", CultureInfo.InvariantCulture) , displayColor));
+        }
+        
+        public static void DisplayDamageResult(int resultDamage, float[] categories)
+        {
+            var displaycolor = Color.White;
+            var dominantAdditionalEffect = DamageType.Physical;
+            float dominantCategory=0;
+            string additionalDamageTypeText= "";
+            
+            for (int i = 2; i < categories.Length; i++) //starting from first real additional damage type
+            {
+                if (dominantCategory < categories[i])
+                {
+                    dominantCategory = categories[i];
+                    dominantAdditionalEffect = (DamageType) i;
+                }
+
+                if (categories[i] > 0)
+                {
+                    DamageType t = (DamageType)i;
+                    string s = ", " +(int) categories[i] + " was dealt in " + t;
+                    if (additionalDamageTypeText == "")
+                        additionalDamageTypeText = s;
+                    else
+                        additionalDamageTypeText.Add(s,false);
+                }
+            }
+
+            switch (dominantAdditionalEffect)
+            {
+                case DamageType.Fire:
+                    displaycolor = Colors.Red;
+                    break;
+                case DamageType.Holy:
+                    displaycolor = Colors.Yellow;
+                    break;
+                case DamageType.Lightning:
+                    displaycolor = Colors.Blue;
+                    break;
+                case DamageType.Magical:
+                    displaycolor = Colors.Cyan;
+                    break;
+            }
+
+            var resultText = (int) resultDamage+ " damage was dealt of which was "+ (int) categories[1]+ " "+ nameof(DamageType.Physical)+additionalDamageTypeText;
+            InformationManager.DisplayMessage(new InformationMessage(resultText, displaycolor));
+            
+        }
+    }
+}


### PR DESCRIPTION
- fixed dot application
- fixed (hopefully) the death initiated by dots
- removed Damage type invalid. The default damage type is now physical
- Damage type all is instead of applying one additional category, adding its damage to all other damage types seperately
- fixed a bug for player characters wielding nonmagical items. if the proportion tuple is not defined, damage is automatically physical
- moved display text for damage values to a separate class 